### PR TITLE
Get UniProt mapping with chembl-downloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.ipynb_checkpoints
+.DS_Store
+.venv

--- a/kinases_in_chembl.ipynb
+++ b/kinases_in_chembl.ipynb
@@ -31,6 +31,7 @@
     "from pathlib import Path\n",
     "import urllib.request\n",
     "\n",
+    "import chembl_downloader\n",
     "import pandas as pd"
    ]
   },
@@ -50,9 +51,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "CHEMBL_VERSION = 29\n",
-    "CHEMBL_VERSION = 30\n",
-    "url = fr\"ftp://ftp.ebi.ac.uk/pub/databases/chembl/ChEMBLdb/releases/chembl_{CHEMBL_VERSION}/chembl_uniprot_mapping.txt\""
+    "# CHEMBL_VERSION = chembl_downloader.latest()\n",
+    "CHEMBL_VERSION = 30"
    ]
   },
   {
@@ -206,8 +206,12 @@
     }
    ],
    "source": [
-    "with urllib.request.urlopen(url) as response:\n",
-    "    uniprot_map = pd.read_csv(response, sep=\"\\t\", skiprows=[0], names=[\"UniprotID\", \"chembl_targets\", \"description\", \"type\"])\n",
+    "uniprot_map = chembl_downloader.get_uniprot_mapping_df(version=CHEMBL_VERSION)\n",
+    "uniprot_map = uniprot_map.rename(columns={\n",
+    "    \"uniprot_id\": \"UniprotID\",\n",
+    "    \"chembl_target_id\": \"chembl_targets\", \n",
+    "    \"name\": \"description\", \n",
+    "})\n",
     "uniprot_map"
    ]
   },


### PR DESCRIPTION
This pull request makes a small change to the **Find UniProt IDs in ChEMBL targets** notebook (`kinases_in_chembl.ipynb`) to use the [`chembl-downloader`](https://github.com/cthoyt/chembl-downloader) package to get the ChEMBL-UniProt target identifier mapping.

The `chembl-downloader` package has the benefit of being able to automatically download the latest ChEMBL data or, in this case, to specify the version.

Ideally, I wanted to re-run this notebook entirely and remove the pin on version 30, but the file `human_kinases.aggregated.csv` is not available in this repo, so I instead just changed the code and not the output.