### PR TITLE
Automate lookup of documents' molecules in `chemicalsp.ipynb`

### DIFF
--- a/chemicalsp.ipynb
+++ b/chemicalsp.ipynb
@@ -28,6 +28,7 @@
     "from sklearn.manifold import TSNE\n",
     "from mlinsights.mlmodel import PredictableTSNE\n",
     "from hdbscan import HDBSCAN\n",
+    "from chembl_downloader.contrib import get_document_smi_df\n",
     "\n",
     "sns.set_context('poster')\n",
     "sns.set_style('white')\n",
@@ -60,9 +61,9 @@
     "companies = []\n",
     "mol_list = []\n",
     "for cid, company in oxrs:\n",
-    "    sdf_file = os.path.join(\"data\", cid + \".sdf\")\n",
-    "    mols = Chem.SDMolSupplier(sdf_file)\n",
-    "    for mol in mols:\n",
+    "    df = get_document_smi_df(cid)\n",
+    "    for smiles in df.canonical_smiles:\n",
+    "        mol = Chem.MolFromSmiles(smiles)\n",
     "        if mol is not None:\n",
     "            mol_list.append(mol)\n",
     "            fp = AllChem.GetMorganFingerprintAsBitVect(mol, 2)\n",
@@ -158,7 +159,7 @@
    "source": [
     "plt.clf()\n",
     "plt.figure(figsize=(12, 6))\n",
-    "sns.scatterplot(res[:,0], res[:,1], hue=companies, **plot_kwds)"
+    "sns.scatterplot(x=res[:,0], y=res[:,1], hue=companies, **plot_kwds)"
    ]
   },
   {
@@ -218,10 +219,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trainFP = [fps[i] for i in trainIDX]\n",
+    "trainFP = fps[trainIDX]\n",
     "train_mol = [mol_list[i] for i in trainIDX]\n",
     "\n",
-    "testFP = [fps[i] for i in testIDX]\n",
+    "testFP = fps[testIDX]\n",
     "test_mol = [mol_list[i] for i in testIDX]"
    ]
   },
@@ -261,12 +262,12 @@
     }
    ],
    "source": [
-    "allFP = trainFP + testFP\n",
+    "allFP = np.vstack([trainFP, testFP])\n",
     "tsne_ref = TSNE(random_state=seed)\n",
     "res = tsne_ref.fit_transform(allFP)\n",
     "plt.clf()\n",
     "plt.figure(figsize=(12, 6))\n",
-    "sns.scatterplot(res[:,0], res[:,1], hue=['train' for i in range(len(trainFP))] + ['test' for i in range(len(testFP))])"
+    "sns.scatterplot(x=res[:,0], y=res[:,1], hue=['train' for i in range(len(trainFP))] + ['test' for i in range(len(testFP))])"
    ]
   },
   {


### PR DESCRIPTION
This pull request makes a small change to `chemicalsp.ipynb` to use the [`chembl-downloader`](https://github.com/cthoyt/chembl-downloader) package to get list of chemicals (and their associated SMILES) based on the documents' ChEMBL identifiers. This is helpful since the data referenced in the notebook wasn't available in the repository.

This PR also makes a few other minor tweaks so the notebook can be fully re-run.

**The updated notebook can be viewed [here](https://nbviewer.org/github/cthoyt/iwatobipen-playground/blob/update-chemical-space-notebook/chemicalsp.ipynb).**